### PR TITLE
Add println lexer test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,14 @@ mod util;
 use util::SrcRegion;
 
 #[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum ErrorKind {
     UnexpectedChar(char),
     UnknownOperator(String),
 }
 
 #[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct Error {
     kind: ErrorKind,
     region: Option<SrcRegion>,

--- a/src/util/intern.rs
+++ b/src/util/intern.rs
@@ -4,6 +4,7 @@ use std::{
     cmp::PartialEq,
 };
 
+#[cfg_attr(test, derive(PartialEq, Debug))]
 pub struct Interned<T>(usize, PhantomData<T>);
 impl<T> Copy for Interned<T> {}
 impl<T> Clone for Interned<T> {
@@ -11,6 +12,7 @@ impl<T> Clone for Interned<T> {
 }
 
 #[derive(Default)]
+#[cfg_attr(test, derive(PartialEq, Debug))]
 pub struct InternTable<T: Eq> {
     items: Vec<T>,
 }

--- a/src/util/src.rs
+++ b/src/util/src.rs
@@ -1,6 +1,10 @@
 use std::fmt;
 
 #[derive(Copy, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+#[cfg(test)]
+pub struct SrcLoc(pub usize);
+#[cfg(not(test))]
 pub struct SrcLoc(usize);
 
 impl SrcLoc {
@@ -45,6 +49,7 @@ impl From<usize> for SrcLoc {
 }
 
 #[derive(Copy, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum SrcRegion {
     None,
     Range(SrcLoc, SrcLoc),


### PR DESCRIPTION
Using `assert_eq!` required that some things implement PartialEq and Debug, but as you can see I configured it so that these traits would only be derived when testing was enabled.

This test should be useful when attempting to optimize or tweak parsing in the future.

Double check the indexes of the source regions, I may be wrong but I believe that there may be some overlap/gaps in the start and end indexes between the regions? I may have miscounted, however.
(The test is currently set up such that it passes)

If you'd like the test to be moved elsewhere, I can manage that.