### PR TITLE
Feature/gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+target/*
+
+Cargo.lock
+
+*.swp
+*.swo

--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -114,8 +114,7 @@ impl Lexeme {
     }
 }
 
-#[derive(Copy, Clone)]
-#[cfg_attr(test, derive(PartialEq, Debug))]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Token {
     pub lexeme: Lexeme,
     pub region: SrcRegion,
@@ -134,7 +133,7 @@ impl Token {
     }
 }
 
-#[cfg_attr(test, derive(PartialEq, Debug))]
+#[derive(PartialEq, Debug)]
 pub struct TokenCtx {
     pub idents: InternTable<String>,
     pub strings: InternTable<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,14 @@ mod util;
 use util::SrcRegion;
 
 #[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum ErrorKind {
     UnexpectedChar(char),
     UnknownOperator(String),
 }
 
 #[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct Error {
     kind: ErrorKind,
     region: Option<SrcRegion>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,7 @@ pub enum Thing {
     Expr,
 }
 
-#[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, PartialEq)]
 pub enum ErrorKind {
     Spurious, // Never revealed to user
     UnexpectedChar(char),
@@ -26,8 +25,7 @@ pub enum ErrorKind {
     Expected(Thing),
 }
 
-#[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, PartialEq)]
 pub struct Error {
     kind: ErrorKind,
     region: Option<SrcRegion>,

--- a/src/util/intern.rs
+++ b/src/util/intern.rs
@@ -11,8 +11,7 @@ impl<T> Clone for Interned<T> {
     fn clone(&self) -> Self { Self(self.0, PhantomData) }
 }
 
-#[derive(Default)]
-#[cfg_attr(test, derive(PartialEq, Debug))]
+#[derive(Default, PartialEq, Debug)]
 pub struct InternTable<T: Eq> {
     items: Vec<T>,
 }

--- a/src/util/intern.rs
+++ b/src/util/intern.rs
@@ -4,6 +4,7 @@ use std::{
     cmp::PartialEq,
 };
 
+#[cfg_attr(test, derive(PartialEq, Debug))]
 pub struct Interned<T>(usize, PhantomData<T>);
 impl<T> Copy for Interned<T> {}
 impl<T> Clone for Interned<T> {
@@ -11,6 +12,7 @@ impl<T> Clone for Interned<T> {
 }
 
 #[derive(Default)]
+#[cfg_attr(test, derive(PartialEq, Debug))]
 pub struct InternTable<T: Eq> {
     items: Vec<T>,
 }

--- a/src/util/src.rs
+++ b/src/util/src.rs
@@ -1,6 +1,10 @@
 use std::fmt;
 
 #[derive(Copy, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+#[cfg(test)]
+pub struct SrcLoc(pub usize);
+#[cfg(not(test))]
 pub struct SrcLoc(usize);
 
 impl SrcLoc {
@@ -45,6 +49,7 @@ impl From<usize> for SrcLoc {
 }
 
 #[derive(Copy, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum SrcRegion {
     None,
     Range(SrcLoc, SrcLoc),

--- a/src/util/src.rs
+++ b/src/util/src.rs
@@ -52,8 +52,7 @@ impl From<usize> for SrcLoc {
     }
 }
 
-#[derive(Copy, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Copy, Clone, PartialEq)]
 pub enum SrcRegion {
     None,
     Range(SrcLoc, SrcLoc),


### PR DESCRIPTION
It bothered me way too much that I was using the wrong naming conventions on my `feature/add-gitignore` PR, so I went ahead and got your latest master, merged that old branch to it creating this branch, and made the commit which derived Debug and PartialEq by default.

In retrospect, I really should've just merged master to the already existing branch even if it did use the wrong naming conventions by having a verb in the branch name, but that was bothering me way too much.

| >.< I'll figure this whole git mess out eventually, I promise...

In conclusion, this branch contains:
the lexer test,
the .gitignore,
and the patch to the derives the lexer test does such that they're universal instead of only being compiled in for the tests.